### PR TITLE
履歴カウントの取りこぼしを防ぐ

### DIFF
--- a/src/server/socket/handlers/extensionEventHandlers.ts
+++ b/src/server/socket/handlers/extensionEventHandlers.ts
@@ -41,6 +41,9 @@ const AUTHORITATIVE_PLAYING_PROMOTION_MS = 3000;
 const AUTHORITATIVE_RESUME_EPSILON_SEC = 0.75;
 const EXTERNAL_VIDEO_TITLE_CACHE_TTL_MS = 10 * 60 * 1000;
 const EXTERNAL_VIDEO_TITLE_CACHE_MAX = 500;
+const HISTORY_PROGRESS_COMPLETION_REMAINING_SEC = 1;
+const HISTORY_REPLAY_RESET_MAX_CURRENT_SEC = 10;
+const HISTORY_REPLAY_RESET_MAX_PROGRESS_RATIO = 0.1;
 
 const isSameVideoOrUnknown = (
     current: RemoteStatus,
@@ -82,10 +85,17 @@ export function setupExtensionEventHandlers(
     void musicDB;
     const extensionSocketOn = extractSocketOn(socket);
     const socketContext = { socketId: socket.id };
+    const recordableMusicSnapshotByVideoId = new Map<string, Music>();
+    const historyCompletionRecordedAtByVideoId = new Map<string, number>();
 
-    const recordHistory = (music: Music | undefined, reason: string) => {
-        if (!music) return;
-        if (!canRecordHistory(music)) return;
+    const rememberRecordableMusic = (music: Music | undefined) => {
+        if (!music || !canRecordHistory(music)) return;
+        recordableMusicSnapshotByVideoId.set(music.id, music);
+    };
+
+    const recordHistory = (music: Music | undefined, reason: string): boolean => {
+        if (!music) return false;
+        if (!canRecordHistory(music)) return false;
         try {
             const historyItem = historyService.recordPlayed(music);
             const emitResult = emitter.emitHistoryAdded(historyItem);
@@ -96,13 +106,82 @@ export function setupExtensionEventHandlers(
                     reason,
                 });
             }
+            return true;
         } catch (error) {
             log.warn('history record failed', {
                 error,
                 musicId: music.id,
                 reason,
             });
+            return false;
         }
+    };
+
+    const recordCompletedHistory = (
+        videoId: string | undefined,
+        reason: string,
+        musicHint?: Music,
+    ): boolean => {
+        if (!videoId) return false;
+
+        const now = Date.now();
+        const lastRecorded = historyCompletionRecordedAtByVideoId.get(videoId);
+        if (lastRecorded) {
+            log.debug('history completion duplicate ignored', {
+                elapsed: now - lastRecorded,
+                reason,
+                videoId,
+            });
+            return false;
+        }
+
+        const music = musicHint ?? repository.get(videoId) ?? recordableMusicSnapshotByVideoId.get(videoId);
+        if (!music) {
+            log.debug('history completion skipped: music snapshot missing', { reason, videoId });
+            return false;
+        }
+
+        rememberRecordableMusic(music);
+        if (!recordHistory(music, reason)) return false;
+
+        historyCompletionRecordedAtByVideoId.set(videoId, now);
+        return true;
+    };
+
+    const isCompletionProgress = (currentTime: number, duration: number): boolean => (
+        duration > 0
+        && currentTime >= 0
+        && duration - currentTime <= HISTORY_PROGRESS_COMPLETION_REMAINING_SEC
+    );
+
+    const clearHistoryCompletionIfReplayStarted = (
+        videoId: string | undefined,
+        currentTime: number | undefined,
+        duration: number | undefined,
+        reason: string,
+    ): void => {
+        if (!videoId || !historyCompletionRecordedAtByVideoId.has(videoId)) return;
+        if (
+            typeof currentTime !== 'number'
+            || typeof duration !== 'number'
+            || duration <= 0
+            || !Number.isFinite(currentTime)
+            || !Number.isFinite(duration)
+        ) { return; }
+
+        const progressRatio = currentTime / duration;
+        const looksLikeReplay = currentTime <= HISTORY_REPLAY_RESET_MAX_CURRENT_SEC
+            || progressRatio <= HISTORY_REPLAY_RESET_MAX_PROGRESS_RATIO;
+        if (!looksLikeReplay) return;
+
+        historyCompletionRecordedAtByVideoId.delete(videoId);
+        log.debug('history completion reset for replay', {
+            currentTime,
+            duration,
+            progressRatio,
+            reason,
+            videoId,
+        });
     };
 
     socket.on('disconnect', reason => {
@@ -119,10 +198,12 @@ export function setupExtensionEventHandlers(
             }, 0);
             const cleanupBefore = {
                 authoritativeVideoState: authoritativeVideoState.size,
+                historyCompletionRecordedAtByVideoId: historyCompletionRecordedAtByVideoId.size,
                 lastAdSnapshotByVideoId: lastAdSnapshotByVideoId.size,
                 lastProgressSnapshotByVideoId: lastProgressSnapshotByVideoId.size,
                 pendingNextByTabId: pendingNextByTabId.size,
                 progressState: progressState.size,
+                recordableMusicSnapshotByVideoId: recordableMusicSnapshotByVideoId.size,
                 socketListenerEvents: socket.eventNames().map(name => String(name)).slice(0, 25),
                 socketListenersTotal: listenersBefore,
                 videoEndDebounce: videoEndDebounce.size,
@@ -131,11 +212,13 @@ export function setupExtensionEventHandlers(
             manager.update({ type: 'closed' }, 'extension_disconnect');
 
             authoritativeVideoState.clear();
+            historyCompletionRecordedAtByVideoId.clear();
             lastProgressSnapshotByVideoId.clear();
             lastAdSnapshotByVideoId.clear();
             videoEndDebounce.clear();
             pendingNextByTabId.clear();
             progressState.clear();
+            recordableMusicSnapshotByVideoId.clear();
             socket.removeAllListeners();
 
             const listenersAfter = socket.eventNames().reduce((sum, name) => {
@@ -148,10 +231,12 @@ export function setupExtensionEventHandlers(
 
             const cleanupAfter = {
                 authoritativeVideoState: authoritativeVideoState.size,
+                historyCompletionRecordedAtByVideoId: historyCompletionRecordedAtByVideoId.size,
                 lastAdSnapshotByVideoId: lastAdSnapshotByVideoId.size,
                 lastProgressSnapshotByVideoId: lastProgressSnapshotByVideoId.size,
                 pendingNextByTabId: pendingNextByTabId.size,
                 progressState: progressState.size,
+                recordableMusicSnapshotByVideoId: recordableMusicSnapshotByVideoId.size,
                 socketListenerEvents: socket.eventNames().map(name => String(name)).slice(0, 25),
                 socketListenersTotal: listenersAfter,
                 videoEndDebounce: videoEndDebounce.size,
@@ -351,9 +436,11 @@ export function setupExtensionEventHandlers(
                 if (url) {
                     const videoId = extractYoutubeId(url);
                     const music = videoId ? repository.get(videoId) : undefined;
+                    rememberRecordableMusic(music);
 
                     // Avoid leaving remoteStatus stuck in 'playing' if video_ended is missed.
                     if (videoId) {
+                        recordCompletedHistory(videoId, 'youtube_video_state:ended', music);
                         try {
                             manager.update(
                                 {
@@ -414,6 +501,7 @@ export function setupExtensionEventHandlers(
                     if (videoId) {
                         const localMusic = repository.get(videoId);
                         if (localMusic) {
+                            rememberRecordableMusic(localMusic);
                             match = {
                                 title: localMusic.title,
                                 url,
@@ -483,6 +571,14 @@ export function setupExtensionEventHandlers(
                     ?? progressSnapshot?.currentTime;
                 const mergedDuration = incomingDuration
                     ?? progressSnapshot?.duration;
+                if (state === 'playing') {
+                    clearHistoryCompletionIfReplayStarted(
+                        resolvedVideoId,
+                        mergedCurrentTime,
+                        mergedDuration,
+                        'youtube_video_state:playing',
+                    );
+                }
 
                 const remoteStatus: RemoteStatus = state === 'playing'
                     ? {
@@ -560,6 +656,7 @@ export function setupExtensionEventHandlers(
                     const preIdx = indexOfMusicById(preList, resolvedVideoId);
                     if (preIdx === -1) return;
                     const endedMusic = preList[preIdx];
+                    rememberRecordableMusic(endedMusic);
 
                     let nextId: string | undefined;
                     if (preList.length > 1) {
@@ -570,7 +667,7 @@ export function setupExtensionEventHandlers(
 
                     const rmRes = repository.remove(resolvedVideoId);
                     if (rmRes.ok) {
-                        recordHistory(endedMusic, 'paused_ended');
+                        recordCompletedHistory(resolvedVideoId, 'paused_ended', endedMusic);
                         emitter.emitMusicRemoved(resolvedVideoId);
                         emitter.emitUrlList(repository.buildCompatList());
                         repository.persistRemove(resolvedVideoId);
@@ -1017,8 +1114,10 @@ export function setupExtensionEventHandlers(
                 const preIndex = indexOfMusicById(preRemoveList, videoId);
                 let nextCandidateId: string | undefined;
                 const endedMusic = preIndex !== -1 ? preRemoveList[preIndex] : undefined;
+                rememberRecordableMusic(endedMusic);
 
                 if (preIndex === -1) {
+                    recordCompletedHistory(videoId, 'video_ended_missing_repository');
                     log.info('video_ended: ignored (video not in repository)', {
                         connectionId,
                         socketId: socket.id,
@@ -1042,7 +1141,7 @@ export function setupExtensionEventHandlers(
 
                 const removeResult = repository.remove(videoId);
                 if (removeResult.ok) {
-                    recordHistory(endedMusic, 'video_ended');
+                    recordCompletedHistory(videoId, 'video_ended', endedMusic);
                     const emitResult = emitter.emitMusicRemoved(videoId);
                     if (!emitResult.ok) {
                         log.warn('video_ended: failed to emit musicRemoved', {
@@ -1393,6 +1492,7 @@ export function setupExtensionEventHandlers(
             state.lastTime = currentTime;
 
             const music = repository.get(videoId);
+            rememberRecordableMusic(music);
             const progressPercent = duration > 0 ? Math.min((currentTime / duration) * 100, 100) : 0;
 
             const stallThreshold = SERVER_ENV.PROGRESS_STALL_THRESHOLD_MS;
@@ -1460,6 +1560,11 @@ export function setupExtensionEventHandlers(
             };
             if (shouldReplaceProgressSnapshot(lastProgressSnapshotByVideoId.get(videoId), progressSnapshot))
                 lastProgressSnapshotByVideoId.set(videoId, progressSnapshot);
+
+            clearHistoryCompletionIfReplayStarted(videoId, currentTime, duration, eventName);
+
+            if (isAdvertisement !== true && isCompletionProgress(currentTime, duration))
+                recordCompletedHistory(videoId, `${eventName}:completion_progress`, music);
 
             const authoritative = authoritativeVideoState.get(videoId);
 

--- a/tests/critical/extensionEventHandlers.video_ended.test.ts
+++ b/tests/critical/extensionEventHandlers.video_ended.test.ts
@@ -5,6 +5,49 @@ import createFakeEmitter from '../helpers/fakeEmitter';
 import createFakeSocket from '../helpers/fakeSocket';
 // removed unused import to satisfy lint
 
+const makeMusic = (id: string, title = id) => ({
+    channelId: 'channel-1',
+    channelName: 'channel name',
+    duration: 'PT3M',
+    id,
+    requestedAt: '2026-06-27T00:00:00.000Z',
+    requesterHash: 'requester-hash',
+    requesterName: 'guest',
+    title,
+});
+
+function createFakeHistoryService() {
+    const calls: any[] = [];
+    return {
+        calls,
+        recordPlayed(music: any) {
+            calls.push(music);
+            return {
+                channelId: music.channelId,
+                channelName: music.channelName,
+                duration: music.duration,
+                firstPlayedAt: new Date().toISOString(),
+                id: music.id,
+                lastPlayedAt: new Date().toISOString(),
+                playCount: calls.filter(call => call.id === music.id).length,
+                requesterHashPrefix: music.requesterHash?.slice(0, 8),
+                requesterName: music.requesterName,
+                title: music.title,
+            };
+        },
+    };
+}
+
+const createManager = () => {
+    let current: any = { type: 'playing', musicId: 'AAAAAAAAAAA', videoId: 'AAAAAAAAAAA' };
+    return {
+        getCurrent: () => current,
+        update: (next: any) => {
+            current = next;
+        },
+    };
+};
+
 describe('video_ended handler', () => {
     test('removes ended video and does not navigate', async () => {
         const socket = createFakeSocket();
@@ -146,5 +189,209 @@ describe('video_ended handler', () => {
         expect(next).toBeUndefined();
         expect(noNext).toBeUndefined();
         expect(repo.list().map(r => r.id)).toEqual(['AAAAAAAAAAA', 'BBBBBBBBBBB']);
+    });
+
+    test('records history from youtube_video_state ended even when video_ended is not received', async () => {
+        const socket = createFakeSocket();
+        const musicMap = new Map();
+        musicMap.set('AAAAAAAAAAA', makeMusic('AAAAAAAAAAA', 'A'));
+        const repo = new MusicRepository(musicMap, undefined as any);
+        const emitter = createFakeEmitter();
+        const manager = createManager();
+        const youtubeService: any = {};
+        const historyService = createFakeHistoryService();
+        const log: any = { debug() {}, info() {}, warn() {} };
+
+        setupExtensionEventHandlers(
+            socket as any,
+            log,
+            'conn',
+            new Map(),
+            manager as any,
+            repo as any,
+            emitter as any,
+            youtubeService,
+            historyService as any,
+        );
+
+        socket.trigger('youtube_video_state', {
+            state: 'ended',
+            url: 'https://youtu.be/AAAAAAAAAAA',
+            currentTime: 180,
+            duration: 180,
+        });
+        await new Promise(res => setTimeout(res, 0));
+
+        expect(historyService.calls.map(m => m.id)).toEqual(['AAAAAAAAAAA']);
+        expect(emitter.getCalls().filter(call => call.event === 'historyAdded')).toHaveLength(1);
+    });
+
+    test('records near-end progress and dedupes later video_ended', async () => {
+        const socket = createFakeSocket();
+        const musicMap = new Map();
+        musicMap.set('AAAAAAAAAAA', makeMusic('AAAAAAAAAAA', 'A'));
+        musicMap.set('BBBBBBBBBBB', makeMusic('BBBBBBBBBBB', 'B'));
+        const repo = new MusicRepository(musicMap, undefined as any);
+        const emitter = createFakeEmitter();
+        const manager = createManager();
+        const youtubeService: any = {};
+        const historyService = createFakeHistoryService();
+        const log: any = { debug() {}, info() {}, warn() {} };
+
+        setupExtensionEventHandlers(
+            socket as any,
+            log,
+            'conn',
+            new Map(),
+            manager as any,
+            repo as any,
+            emitter as any,
+            youtubeService,
+            historyService as any,
+        );
+
+        socket.trigger('youtube_video_state', {
+            state: 'playing',
+            url: 'https://youtu.be/AAAAAAAAAAA',
+            currentTime: 170,
+            duration: 180,
+            seq: 1,
+        });
+        socket.trigger('progress_update', {
+            url: 'https://youtu.be/AAAAAAAAAAA',
+            currentTime: 179.2,
+            duration: 180,
+            playbackRate: 1,
+            timestamp: Date.now(),
+            visibilityState: 'visible',
+            seq: 2,
+        });
+        await new Promise(res => setTimeout(res, 0));
+
+        socket.trigger('video_ended', { url: 'https://youtu.be/AAAAAAAAAAA', tabId: 42 });
+        await new Promise(res => setTimeout(res, 0));
+
+        expect(historyService.calls.map(m => m.id)).toEqual(['AAAAAAAAAAA']);
+        expect(emitter.getCalls().filter(call => call.event === 'historyAdded')).toHaveLength(1);
+        expect(repo.list().map(r => r.id)).toEqual(['BBBBBBBBBBB']);
+    });
+
+    test('does not recount repeated near-end progress after completion', async () => {
+        const socket = createFakeSocket();
+        const musicMap = new Map();
+        musicMap.set('AAAAAAAAAAA', makeMusic('AAAAAAAAAAA', 'A'));
+        const repo = new MusicRepository(musicMap, undefined as any);
+        const emitter = createFakeEmitter();
+        const manager = createManager();
+        const youtubeService: any = {};
+        const historyService = createFakeHistoryService();
+        const log: any = { debug() {}, info() {}, warn() {} };
+
+        setupExtensionEventHandlers(
+            socket as any,
+            log,
+            'conn',
+            new Map(),
+            manager as any,
+            repo as any,
+            emitter as any,
+            youtubeService,
+            historyService as any,
+        );
+
+        const now = Date.now();
+        socket.trigger('youtube_video_state', {
+            state: 'playing',
+            url: 'https://youtu.be/AAAAAAAAAAA',
+            currentTime: 170,
+            duration: 180,
+            seq: 1,
+        });
+        socket.trigger('progress_update', {
+            url: 'https://youtu.be/AAAAAAAAAAA',
+            currentTime: 179.2,
+            duration: 180,
+            playbackRate: 1,
+            timestamp: now,
+            visibilityState: 'visible',
+            seq: 2,
+        });
+        socket.trigger('progress_update', {
+            url: 'https://youtu.be/AAAAAAAAAAA',
+            currentTime: 179.8,
+            duration: 180,
+            playbackRate: 1,
+            timestamp: now + 6000,
+            visibilityState: 'visible',
+            seq: 3,
+        });
+        await new Promise(res => setTimeout(res, 0));
+
+        expect(historyService.calls.map(m => m.id)).toEqual(['AAAAAAAAAAA']);
+        expect(emitter.getCalls().filter(call => call.event === 'historyAdded')).toHaveLength(1);
+    });
+
+    test('allows recount after the same video starts over from the beginning', async () => {
+        const socket = createFakeSocket();
+        const musicMap = new Map();
+        musicMap.set('AAAAAAAAAAA', makeMusic('AAAAAAAAAAA', 'A'));
+        const repo = new MusicRepository(musicMap, undefined as any);
+        const emitter = createFakeEmitter();
+        const manager = createManager();
+        const youtubeService: any = {};
+        const historyService = createFakeHistoryService();
+        const log: any = { debug() {}, info() {}, warn() {} };
+
+        setupExtensionEventHandlers(
+            socket as any,
+            log,
+            'conn',
+            new Map(),
+            manager as any,
+            repo as any,
+            emitter as any,
+            youtubeService,
+            historyService as any,
+        );
+
+        const now = Date.now();
+        socket.trigger('youtube_video_state', {
+            state: 'playing',
+            url: 'https://youtu.be/AAAAAAAAAAA',
+            currentTime: 170,
+            duration: 180,
+            seq: 1,
+        });
+        socket.trigger('progress_update', {
+            url: 'https://youtu.be/AAAAAAAAAAA',
+            currentTime: 179.2,
+            duration: 180,
+            playbackRate: 1,
+            timestamp: now,
+            visibilityState: 'visible',
+            seq: 2,
+        });
+        socket.trigger('progress_update', {
+            url: 'https://youtu.be/AAAAAAAAAAA',
+            currentTime: 2,
+            duration: 180,
+            playbackRate: 1,
+            timestamp: now + 1000,
+            visibilityState: 'visible',
+            seq: 3,
+        });
+        socket.trigger('progress_update', {
+            url: 'https://youtu.be/AAAAAAAAAAA',
+            currentTime: 179.4,
+            duration: 180,
+            playbackRate: 1,
+            timestamp: now + 2000,
+            visibilityState: 'visible',
+            seq: 4,
+        });
+        await new Promise(res => setTimeout(res, 0));
+
+        expect(historyService.calls.map(m => m.id)).toEqual(['AAAAAAAAAAA', 'AAAAAAAAAAA']);
+        expect(emitter.getCalls().filter(call => call.event === 'historyAdded')).toHaveLength(2);
     });
 });


### PR DESCRIPTION
## Summary
- サーバー側で `youtube_video_state: ended` と終端付近の progress を履歴記録に活用
- 同一視聴の重複カウントを防ぎ、同じ動画の再再生時だけ再カウントできるよう調整
- 履歴カウントの取りこぼし・重複防止テストを追加

## Test plan
- `bun run tsc`
- `bun test tests/critical/extensionEventHandlers.video_ended.test.ts tests/critical/extensionEventHandlers.progress_ordering.test.ts tests/critical/extensionEventHandlers.progress_ad_detection.test.ts`


Made with [Cursor](https://cursor.com)